### PR TITLE
visors and vendors

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -413,7 +413,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	var/helmet_band_icon = 'icons/mob/humans/onmob/clothing/helmet_garb/misc.dmi'
 
 	///Any visors built into the helmet
-	var/list/built_in_visors = list(new /obj/item/device/helmet_visor)
+	var/list/built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/welding_visor/tanker, new /obj/item/device/helmet_visor/medical/advanced)
 	///Any visors that have been added into the helmet
 	var/list/inserted_visors = list()
 	///Max amount of inserted visors
@@ -812,7 +812,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	desc = "A modified M10 marine helmet for ComTechs. Features a toggleable welding screen for eye protection."
 	icon_state = "tech_helmet"
 	specialty = "M10 technician"
-	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/welding_visor)
+	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/welding_visor/tanker, new /obj/item/device/helmet_visor/medical/advanced)
 	clothing_traits = list(TRAIT_EAR_PROTECTION)
 
 /obj/item/clothing/head/helmet/marine/welding
@@ -883,14 +883,14 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	flags_inventory = BLOCKSHARPOBJ
 	flags_inv_hide = HIDEEARS|HIDETOPHAIR
 	specialty = "M50 tanker"
-	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/welding_visor/tanker)
+	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/welding_visor/tanker, new /obj/item/device/helmet_visor/medical/advanced)
 
 /obj/item/clothing/head/helmet/marine/medic
 	name = "\improper M10 corpsman helmet"
 	desc = "An M10 marine helmet version worn by marine hospital corpsmen. Has red cross painted on its front."
 	icon_state = "med_helmet"
 	specialty = "M10 pattern medic"
-	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/medical/advanced)
+	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/welding_visor/tanker, new /obj/item/device/helmet_visor/medical/advanced)
 	start_down_visor_type = /obj/item/device/helmet_visor/medical/advanced
 
 /obj/item/clothing/head/helmet/marine/medic/white

--- a/code/modules/pve/pve_vendors.dm
+++ b/code/modules/pve/pve_vendors.dm
@@ -1,3 +1,52 @@
+/obj/structure/machinery/cm_vending/sorted/pve/uniform/general
+	name = "\improper UAR General Uniform Rack"
+	desc = "A secure uniform storage sollution, linked to a general, shared storage."
+	req_access = list()
+	vend_flags = VEND_CLUTTER_PROTECTION | VEND_UNIFORM_AUTOEQUIP | VEND_LIMITED_INVENTORY
+
+/obj/structure/machinery/cm_vending/sorted/pve/uniform/general/get_listed_products(mob/user)
+	return list(
+	list("STANDARD EQUIPMENT", 0, null, null, null),
+	list("Gloves", 20, /obj/item/clothing/gloves/marine, MARINE_CAN_BUY_GLOVES, VENDOR_ITEM_MANDATORY),
+	list("Headset", 20, /obj/item/device/radio/headset/almayer/mmpo, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
+	list("Marine Combat Boots", 20, /obj/item/clothing/shoes/marine/knife, MARINE_CAN_BUY_SHOES, VENDOR_ITEM_MANDATORY),
+	list("UNIFORMS", 0, null, null, null),
+	list("Standard", 20, /obj/item/clothing/under/marine/, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
+	list("Medic", 20, /obj/item/clothing/under/marine/medic/, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
+	list("Engineer", 20, /obj/item/clothing/under/marine/engineer/, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
+	list("Engineer - alternative", 20, /obj/item/clothing/under/marine/engineer/, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
+	list("Radio Officer", 20, /obj/item/clothing/under/marine/rto/, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
+	list("Vehicle Operator", 20, /obj/item/clothing/under/marine/tanker/, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
+	)
+
+
+/obj/structure/machinery/cm_vending/sorted/pve/uniform
+	name = "\improper UAR Armor Vendor"
+	desc = "An automated supply rack hooked up to a big storage of standard marine uniforms. Can be accessed by the Requisitions Officer and Cargo Techs."
+	icon_state = "clothing"
+	req_access = list()
+	req_one_access = list()
+	hackable = TRUE
+	vend_flags = VEND_CLUTTER_PROTECTION | VEND_UNIFORM_AUTOEQUIP | VEND_LIMITED_INVENTORY
+	vendor_theme = VENDOR_THEME_USCM
+
+	listed_products = list(
+
+		list("STANDARD HELMETS", -1, null, null),
+		list("M10 Pattern Marine Helmet - No camo", 20, /obj/item/clothing/head/helmet/marine/grey, VENDOR_ITEM_RECOMMENDED),
+		list("M10 Pattern Marine Helmet - Jungle camo", 20, /obj/item/clothing/head/helmet/marine/jungle, VENDOR_ITEM_REGULAR),
+		list("M10 Pattern Marine Helmet - Snow camo", 20, /obj/item/clothing/head/helmet/marine/snow, VENDOR_ITEM_REGULAR),
+		list("M10 Pattern Marine Helmet - Desert camo", 20, /obj/item/clothing/head/helmet/marine/desert, VENDOR_ITEM_REGULAR),
+		list("SPECIALIZED HELMETS", -1, null, null),
+		list("M10 Pattern Technician Helmet", 20, /obj/item/clothing/head/helmet/marine/tech, VENDOR_ITEM_REGULAR),
+		list("M10 Pattern Corspman Helmet", 20, /obj/item/clothing/head/helmet/marine/medic, VENDOR_ITEM_REGULAR),
+		list("STANDARD ARMOR", -1, null, null),
+		list("M3 Pattern Marine Armor", 20, /obj/item/clothing/suit/storage/marine/, VENDOR_ITEM_RECOMMENDED),
+		list("SPECIALIZED ARMOR", -1, null, null),
+		list("M3-EOD Pattern Heavy Armor", 20, /obj/item/clothing/suit/storage/marine/heavy, VENDOR_ITEM_REGULAR),
+		list("M3-L Pattern Light Armor", 20, /obj/item/clothing/suit/storage/marine/light, VENDOR_ITEM_REGULAR),
+	)
+
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/pve/guns
 	name = "\improper UAR Automated Weapons Rack"
 	desc = "An automated weapon rack hooked up to a big storage of standard-issue weapons."


### PR DESCRIPTION
Adds eye protection and medical visors to Marine helmets by default
Ports Xenosruge uniform etc. Vendors for a complete set to speed up prep